### PR TITLE
Add hint for "newscheck" group in write_read_list

### DIFF
--- a/src/read_list.rs
+++ b/src/read_list.rs
@@ -1,7 +1,7 @@
 use std::fs::{read, File};
 use std::io::ErrorKind;
 use crate::feed::Entry;
-use crate::term::{print_warning};
+use crate::term::print_warning;
 
 const HASH_SIZE: usize = 16;
 

--- a/src/read_list.rs
+++ b/src/read_list.rs
@@ -1,6 +1,7 @@
 use std::fs::{read, File};
 use std::io::ErrorKind;
 use crate::feed::Entry;
+use crate::term::{print_warning};
 
 const HASH_SIZE: usize = 16;
 
@@ -31,6 +32,11 @@ fn check_read(read_list: &Vec<u8>, entry: &Entry) -> bool {
 
 pub fn write_read_list(path: &str, read_list: Vec<u8>) -> std::io::Result<()> {
     std::fs::write(path, read_list)
+        .inspect_err(|e| {
+            if e.kind() == ErrorKind::PermissionDenied {
+                print_warning("Could not write to the read list. You must be in the \"newscheck\" group to do this.");
+            }
+        })
 }
 
 pub fn add_to_read_list(read_list: &mut Vec<u8>, entry: &Entry) {


### PR DESCRIPTION
Warn the user about adding themselves to the "newscheck" group if writing to read list fails with a permission error. If the user missed the pacman post-install output, then "Permission denied (os error 13)" is confusing without this clarification (#1).